### PR TITLE
Update mkdeb.sh

### DIFF
--- a/rocrail/mkdeb.sh
+++ b/rocrail/mkdeb.sh
@@ -75,7 +75,7 @@ cp -R ../rocview/svg/* debian/opt/rocrail/svg
 cp -R ../rocrail/impl/web/html/* debian/opt/rocrail/web
 cp -R ../COPYING debian/opt/rocrail
 
-fakeroot dpkg-deb --build debian
+fakeroot 'dpkg-deb --build debian'
 mv debian.deb rocrail-$BAZAARREV-$DIST-$ARCH.deb
 rm -Rf debian
 cd ../rocrail


### PR DESCRIPTION
I just compiled rocrail on a newly installed Ubuntu 14.04 system, and I had to make a couple of tweaks to get the 'mkdeb.sh' script working:
- chmod g-s package
- added the single quotes on the mkdeb.sh file, in the fakeroot command.